### PR TITLE
Make fixes for API changes, fly.io. email freq

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,13 +9,13 @@ primary_region = 'den'
 [http_service]
 internal_port = 8080
 force_https = true
-auto_stop_machines = true
-auto_start_machines = true
+auto_stop_machines = false
+auto_start_machines = false
 min_machines_running = 0
 processes = ['app']
 
 [[vm]]
-memory = '1gb'
+memory = '256mb'
 cpu_kind = 'shared'
 cpus = 1
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import datetime as dt
 import dotenv
 import logging
 import sys
+import json
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -52,10 +53,12 @@ def send_message(msg):
 
 def check_dates():
     url = "https://casatix-api.casabonitadenver.com/api/v2/search"
+    headers = {
+        "Accept":"*/*",
+        "User-Agent":"Mozilla/5.0"
+    }
     params = {
-
         "booking_code": BOOKING_CODE,
-        "fc_token": "",
         "party_size": PARTY_SIZE,
         "res_date": "",
         "service": "dinner"
@@ -72,38 +75,30 @@ def check_dates():
         if date in unavailable_dates:
             continue
         params["res_date"] = date.isoformat()
-        res = session.get(url, params=params, timeout=10)
-        if res.status_code != 200:
-            if "This code cannot be used for visits after" in res.json().get("display_error", ""):
-                print(f"No more dates after {date}")
+        res = session.get(url, headers=headers,params=params, timeout=10)
+        if res.status_code == 400:
+            if "Unable to search date" in res.json().get("display_error", ""):
+                print(f"{date} is not available yet.")
                 break
+            if "This code cannot be used for visits after" in res.json().get("display_error", ""):
+                print(f"No more dates after {date}.")
+                break
+        if res.status_code != 200:
             print(f"Error: {res.status_code}\n{res.text}")
             continue
-        data = res.json()
-        if data['times_available']:
-            # the results look like this: {'times_available': [{'time': '2024-02-27T20:30', 'experiences': [{'id': 171289, 'name': 'Traditional Dining'}]}], 'experiences_by_id': {'171289': {'item_id': 2, 'name': 'Traditional Dining', 'description': 'The traditional Casa Bonita experience with the opportunity to sit in multiple dining areas such as the Plaza, Gold Mine, Limestone Caverns, etc.', 'description_detail': '<ul>\r\n<li> Each ticket includes an entree of incredible Mexican food, chips & salsa, a soft drink, and of course, sopaipillas!</li>\r\n<li> Everyone age 3 and up must purchase a ticket to enter the restaurant.</li>\r\n<li> Alcoholic beverages and other menu items are sold separately.</li>\r\n<li> Ticket holder must show ID to enter.</li>\r\n</ul>', 'price_description': '$39.99 / Adults<br>$24.99 / Kids (age 3-12)', 'prices': {'adult': '39.99', 'child': '24.99', 'baby': '0.00', 'flex': '10.00'}, 'flex_allowed': True, 'skus': {'adult': 'ga_dinner_adult', 'child': 'ga_dinner_child', 'baby': 'baby'}, 'id': 171289, 'version': 4}, '171306': {'item_id': 3, 'name': 'Cliffside Dining', 'description': 'A premium dining experience for those who wish to skip the line and sit cliffside with dedicated table service.', 'description_detail': '<ul>\r\n<li> Each ticket includes an entree of incredible Mexican food, chips & salsa, a soft drink, and of course, sopaipillas!</li>\r\n<li> Everyone age 3 and up must purchase a ticket to enter the restaurant.</li>\r\n<li> Alcoholic beverages and other menu items are sold separately.</li>\r\n<li> Ticket holder must show ID to enter.</li>\r\n</ul>', 'price_description': '$44.99 / per person', 'prices': {'adult': '44.99', 'child': '44.99', 'baby': '0.00', 'flex': '10.00'}, 'flex_allowed': True, 'skus': {'adult': 'premium_dinner_adult', 'child': 'premium_dinner_child', 'baby': 'baby'}, 'id': 171306, 'version': 2}, '204321': {'item_id': 6, 'name': 'Traditional Dining - Lunch', 'description': "The traditional Casa Bonita experience with the opportunity to sit in multiple dining areas such as the Plaza, Governor's Palace, Gold Mine, Limestone Caverns, etc.", 'description_detail': '<ul>\r\n<li> Each ticket includes an entree of incredible Mexican food, chips & salsa, a soft drink, and of course, sopaipillas!</li>\r\n<li> Everyone age 3 and up must purchase a ticket to enter the restaurant.</li>\r\n<li> Alcoholic beverages and other menu items are sold separately.</li>\r\n<li> Ticket holder must show ID to enter.</li>\r\n</ul>', 'price_description': '$29.99 / Adults<br>$19.99 / Kids (age 3-12)', 'prices': {'adult': '29.99', 'child': '19.99', 'baby': '0.00', 'flex': '10.00'}, 'flex_allowed': True, 'skus': {'adult': 'ga_lunch_adult', 'child': 'ga_lunch_child', 'baby': 'baby'}, 'id': 204321, 'version': 1}, '204323': {'item_id': 5, 'name': 'Cliffside Dining - Lunch', 'description': 'A premium dining experience for those who wish to skip the line and sit cliffside with dedicated table service.', 'description_detail': '<ul>\r\n<li> Each ticket includes an entree of incredible Mexican food, chips & salsa, a soft drink, and of course, sopaipillas!</li>\r\n<li> Everyone age 3 and up must purchase a ticket to enter the restaurant.</li>\r\n<li> Alcoholic beverages and other menu items are sold separately.</li>\r\n<li> Ticket holder must show ID to enter.</li>\r\n</ul>', 'price_description': '$34.99 / per person', 'prices': {'adult': '34.99', 'child': '34.99', 'baby': '0.00', 'flex': '10.00'}, 'flex_allowed': True, 'skus': {'adult': 'premium_lunch_adult', 'child': 'premium_lunch_child', 'baby': 'baby'}, 'id': 204323, 'version': 1}}}
-            # get a list of names of experiences from all times_available
-            experiences = []
-            for _time in data['times_available']:
-                for exp in _time['experiences']:
-                    experiences.append(exp['name'])
-            print(experiences, date)
-            if "Cliffside Dining" in experiences:
-                print(f"{date} has Cliffside Dining")
-                print()
-                messages.append(f"{date} has Cliffside Dining")
-                # send_message(f"{date} has Cliffside Dining")
-            # check if any of the options are not Traditional Dining
-            elif any(exp not in ["Traditional Dining"] for exp in experiences):
-                print(f"{date} has other options")
-                print()
-                messages.append(f"{date} has other options")
-                # send_message(f"{date} has other options")
-            else:
-                print(f"{date} has Traditional Dining")
-                print()
-                # if you want to be notified of Traditional Dining, uncomment the next line
-                # messages.append(f"{date} has Traditional Dining")
+        try:
+            data = res.json()
+            # print(json.dumps(data,indent=2))
+            if 'times_by_table_type' in data:
+                if len(data['times_by_table_type']['default'])>0:
+                    print(f"{date} has Traditional Dining available for {PARTY_SIZE} people.")
+                    messages.append(f"{date} has Traditional Dining available for {PARTY_SIZE} people.")
+                if len(data['times_by_table_type']['counter'])>0:
+                    print(f"{date} has Cliffside Dining available for {PARTY_SIZE} people.")
+                    messages.append(f"{date} has Cliffside Dining available for {PARTY_SIZE} people.")
+        except json.decoder.JSONDecodeError:
+            print("You might need to solve a captcha.")
+            messages.append("You might need to solve a captcha through the url below.")
 
     if messages:
         send_message("<br />".join(messages))
@@ -115,4 +110,4 @@ if __name__ == '__main__':
         print(f"### {dt.datetime.now()} ###")
         logger.info(f"Checking dates")
         check_dates()
-        time.sleep(600)
+        time.sleep(900)


### PR DESCRIPTION
The casa bonita api has changed. It now requires the headers I've included and removal of the fc_token param. The response format has also changed so I've updated the parsing of that accordingly. Also they once in a while return a captcha which breaks the res.json() call so if the app notices that then you'll get an email notifying you to solve the captcha which will unblock the bot until the next time a captcha gets returned.

I've updated the fly.toml so the machine doesn't auto shut off during the sleep cycle. And also reduce the size of the machine to the free tier size.

Sendgrid free tier only allows 100 emails a day so I reduced the frequency of emails being sent out to comply with that.